### PR TITLE
Use escape_utils if available, fall-back on CGI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Default configuration integrates with Rails, but you can change it with an initi
     Emoji.asset_host = "emoji.cdn.com"
     Emoji.asset_path = '/assets/emoji'
     
+## HTML Safety and Performance
+
+This gem uses pure ruby code for compatibility with different Ruby virtual machines.  However, there can be significant performance gains to escaping incoming HTML strings using optimized, native code in the `escape_utils` gem.
+
+The emoji gem will try to use `escape_utils` if it's available, but does not require it.  [Benchmarks show a 10x-100x improvement](https://gist.github.com/wpeterson/c851be471bd91868716c) in HTML escaping performance, based on the size of the string being processed.
+
+To enable native HTML escaping, add this line to your application's Gemfile:
+
+    gem 'escape_utils'
+
 
 ## Contributing
 

--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -1,6 +1,12 @@
 require 'emoji/version'
 require 'json'
-require 'cgi'
+
+# Optionally load EscapeUtils if it's available
+begin
+  require 'escape_utils'
+rescue LoadError
+  require 'cgi'
+end
 
 require 'emoji/index'
 
@@ -9,6 +15,7 @@ require "emoji/railtie" if defined?(Rails)
 module Emoji
   @asset_host = nil
   @asset_path = nil
+  @escaper = defined?(EscapeUtils) ? EscapeUtils : CGI
 
   def self.asset_host
     @asset_host || 'http://localhost:3000'
@@ -43,7 +50,7 @@ module Emoji
     if string.respond_to?(:html_safe?) && string.html_safe?
       safe_string = string
     else
-      safe_string = CGI.escape_html(string)
+      safe_string = escape_html(string)
     end
 
     safe_string.gsub!(index.unicode_moji_regex) do |moji|
@@ -52,6 +59,10 @@ module Emoji
     safe_string = safe_string.html_safe if safe_string.respond_to?(:html_safe)
 
     safe_string
+  end
+
+  def self.escape_html(string)
+    @escaper.escape_html(string)
   end
 
   def self.index


### PR DESCRIPTION
- Try to load `escape_utils` and gracefully handle missing requirement
- Fall back on CGI.escape_html implementation
- Update README to explain how to use `escape_utils`

[Benchmarks showing 10x-100x improvement](https://gist.github.com/wpeterson/c851be471bd91868716c).
