### PR TITLE
Add alt text to images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Image Replacement APIs:
 
 ```ruby
 > Emoji.replace_unicode_moji_with_images('I ❤ Emoji')
-=> "I <img class=\"emoji\" src=\"http://localhost:3000/assets/emoji/heart.png\"> Emoji"
+=> "I <img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/assets/emoji/heart.png\"> Emoji"
 
 > Emoji.image_url_for_unicode_moji('❤')
 => "http://localhost:3000/assets/emoji/heart.png"
@@ -81,7 +81,7 @@ and call methods directly on your string to return the same results:
 
 ```ruby
 > 'I ❤ Emoji'.with_emoji_images
-=> "I <img class=\"emoji\" src=\"http://localhost:3000/assets/emoji/heart.png\"> Emoji"
+=> "I <img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/assets/emoji/heart.png\"> Emoji"
 
 > 'heart'.image_url
 > '❤'.image_url

--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -54,7 +54,7 @@ module Emoji
     end
 
     safe_string.gsub!(index.unicode_moji_regex) do |moji|
-      %Q{<img class="emoji" src="#{ image_url_for_unicode_moji(moji) }">}
+      %Q{<img alt="#{moji}" class="emoji" src="#{ image_url_for_unicode_moji(moji) }">}
     end
     safe_string = safe_string.html_safe if safe_string.respond_to?(:html_safe)
 

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -46,13 +46,13 @@ describe Emoji do
 
     it 'should escape html in non html_safe aware strings' do
       replaced_string = Emoji.replace_unicode_moji_with_images('❤<script>')
-      assert_equal "<img class=\"emoji\" src=\"http://localhost:3000/heart.png\">&lt;script&gt;", replaced_string
+      assert_equal "<img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/heart.png\">&lt;script&gt;", replaced_string
     end
 
     it 'should replace unicode moji with img tag' do
       base_string = "I ❤ Emoji"
       replaced_string = Emoji.replace_unicode_moji_with_images(base_string)
-      assert_equal "I <img class=\"emoji\" src=\"http://localhost:3000/heart.png\"> Emoji", replaced_string
+      assert_equal "I <img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/heart.png\"> Emoji", replaced_string
     end
 
     it 'should handle nil string' do
@@ -67,7 +67,7 @@ describe Emoji do
           Emoji.replace_unicode_moji_with_images(string)
         end
 
-        assert_equal "<img class=\"emoji\" src=\"http://localhost:3000/heart.png\">&lt;script&gt;", replaced_string
+        assert_equal "<img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/heart.png\">&lt;script&gt;", replaced_string
       end
 
       it 'should not escape html_safe strings' do
@@ -77,7 +77,7 @@ describe Emoji do
           Emoji.replace_unicode_moji_with_images(string)
         end
         
-        assert_equal "<img class=\"emoji\" src=\"http://localhost:3000/heart.png\"><a href=\"harmless\">", replaced_string
+        assert_equal "<img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/heart.png\"><a href=\"harmless\">", replaced_string
       end
 
       it 'should always return an html_safe string' do

--- a/test/string_ext_test.rb
+++ b/test/string_ext_test.rb
@@ -7,7 +7,7 @@ describe String, 'with Emoji extensions' do
     it 'should replace unicode moji with an img tag' do
       base_string = "I ❤ Emoji"
       replaced_string = base_string.with_emoji_images
-      assert_equal "I <img class=\"emoji\" src=\"http://localhost:3000/heart.png\"> Emoji", replaced_string
+      assert_equal "I <img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/heart.png\"> Emoji", replaced_string
     end
   end
 


### PR DESCRIPTION
Replacing Unicode characters with image tags without alt text renders them invisible to non-graphical user agents, which could otherwise have made an attempt at either displaying them as text or interpreting them as speech.

(I'm not really a fan of emoji, but they're everywhere these days, so we may as well render them in a way which is accessible to as many users as possible.)
