### PR TITLE
Add replace unicode moji with name

### DIFF
--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -47,7 +47,6 @@ module Emoji
       hostname = uri.hostname || uri.path
       port_string = extract_port_string(uri)
     end
-      
      "#{ scheme_string }#{ hostname }#{ port_string }"
   end
 
@@ -126,6 +125,22 @@ module Emoji
     safe_string = safe_string(string.dup)
     safe_string.gsub!(index.unicode_moji_regex) do |moji|
       %Q{<img alt="#{alt_tag_for_moji(moji)}" class="emoji" src="#{ image_url_for_unicode_moji(moji) }">}
+    end
+    safe_string = safe_string.html_safe if safe_string.respond_to?(:html_safe)
+
+    safe_string
+  end
+
+  def self.replace_unicode_moji_with_name(string)
+    return string unless string
+    unless string.match(index.unicode_moji_regex)
+      return safe_string(string)
+    end
+
+    safe_string = safe_string(string.dup)
+    safe_string.gsub!(index.unicode_moji_regex) do |moji|
+      emoji = index.find_by_moji(moji)
+      %Q{:#{emoji['name']}:}
     end
     safe_string = safe_string.html_safe if safe_string.respond_to?(:html_safe)
 

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -104,6 +104,16 @@ describe Emoji do
     end
   end
 
+  describe 'replace_unicode_moji_with_name' do
+    it 'should return original string without emoji' do
+      assert_equal "foo", Emoji.replace_unicode_moji_with_name('foo')
+    end
+    it 'should replace an emoji with its ascii name' do
+      base_string = "I ❤ Emoji"
+      assert_equal "I :heart: Emoji", Emoji.replace_unicode_moji_with_name(base_string)
+    end
+  end
+
   describe "replace_unicode_moji_with_images" do
     it 'should return original string without emoji' do
       assert_equal "foo", Emoji.replace_unicode_moji_with_images('foo')
@@ -159,7 +169,7 @@ describe Emoji do
         replaced_string = string.stub(:html_safe?, true) do
           Emoji.replace_unicode_moji_with_images(string)
         end
-        
+
         assert_equal "<img alt=\"❤\" class=\"emoji\" src=\"http://localhost:3000/heart.png\"><a href=\"harmless\">", replaced_string
       end
 


### PR DESCRIPTION
Adds another method to turn unicode emoji into the colon delimited string version.

so
"I ❤ Emoji" => "I `:heart:` Emoji"

useful for switching back to a text preview of markup.