### PR TITLE
Use rails asset prefix as default asset_path configuration

### DIFF
--- a/lib/emoji/railtie.rb
+++ b/lib/emoji/railtie.rb
@@ -5,7 +5,7 @@ module Emoji
   class Railtie < Rails::Railtie
     initializer "emoji.defaults" do
       Emoji.asset_host = ActionController::Base.asset_host
-      Emoji.asset_path = '/assets/emoji'
+      Emoji.asset_path = "#{config.assets.prefix}/emoji"
       Emoji.use_plaintext_alt_tags = false
     end
 


### PR DESCRIPTION
Would be good to use ``config.assets.prefix`` as the default asset path, because you often set this to anything other than default if you precompile locally, http://guides.rubyonrails.org/asset_pipeline.html#local-precompilation

