### PR TITLE
Markdown

### DIFF
--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -117,6 +117,17 @@ module Emoji
     emoji['name']
   end
 
+  def self.replace_markdown_moji_with_unicode(string)
+    return string unless string
+    string.gsub!(/:\S+:/) do |m|
+      # puts m[1..-2]
+      # puts index.find_by_name(m[1,-2])
+      emoji = index.find_by_name(m[1..-2])
+      emoji['moji']
+    end
+    string
+  end
+
   def self.replace_unicode_moji_with_images(string)
     return string unless string
     unless string.match(index.unicode_moji_regex)

--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -119,14 +119,22 @@ module Emoji
 
   def self.replace_markdown_moji_with_unicode(string)
     return string unless string
-    string.gsub!(/:\S+:/) do |m|
-      # puts m[1..-2]
-      # puts index.find_by_name(m[1,-2])
-      emoji = index.find_by_name(m[1..-2])
+    string.gsub!(/:\S+:/) do |moji|
+      emoji = index.find_by_name(moji[1..-2])
       emoji['moji']
     end
     string
   end
+
+  def self.replace_moji_with_markdown(string)
+    return string unless string
+    string.gsub!(index.unicode_moji_regex) do |moji|
+      emoji = index.find_by_moji(moji)
+      ':' + emoji['name'] + ':'
+    end
+    string
+  end
+
 
   def self.replace_unicode_moji_with_images(string)
     return string unless string

--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -126,16 +126,6 @@ module Emoji
     string
   end
 
-  def self.replace_moji_with_markdown(string)
-    return string unless string
-    string.gsub!(index.unicode_moji_regex) do |moji|
-      emoji = index.find_by_moji(moji)
-      ':' + emoji['name'] + ':'
-    end
-    string
-  end
-
-
   def self.replace_unicode_moji_with_images(string)
     return string unless string
     unless string.match(index.unicode_moji_regex)

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -114,6 +114,22 @@ describe Emoji do
     end
   end
 
+  describe 'replace_markdown_moji_with_unicode' do
+    it 'should return the original string without emoji' do
+      assert_equal "foo", Emoji.replace_unicode_moji_with_name('foo')
+    end
+
+    it 'should replace the markdown-esque emoji name with its unicode equivalent' do
+      base_string = "I :heart: Emoji"
+      assert_equal "I ❤ Emoji", Emoji.replace_markdown_moji_with_unicode(base_string)
+    end
+
+    it 'should be able to replace multiple emoji in one go' do
+      base_string = "I :heart: :heart: Emoji"
+      assert_equal "I ❤ ❤ Emoji", Emoji.replace_markdown_moji_with_unicode(base_string)
+    end
+  end
+
   describe "replace_unicode_moji_with_images" do
     it 'should return original string without emoji' do
       assert_equal "foo", Emoji.replace_unicode_moji_with_images('foo')

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -130,22 +130,6 @@ describe Emoji do
     end
   end
 
-  describe "replace_moji_with_markdown" do
-    it 'should return the original string without emoji' do
-      assert_equal "foo", Emoji.replace_moji_with_markdown('foo')
-    end
-
-    it 'should replace the unicode moji with markdown moji names' do
-      base_string = "I ❤ Emoji"
-      assert_equal "I :heart: Emoji", Emoji.replace_moji_with_markdown(base_string)
-    end
-
-    it 'should be able to replace multiple moji in one go' do
-      base_string = "I ❤ ❤ Emoji"
-      assert_equal "I :heart: :heart: Emoji", Emoji.replace_moji_with_markdown(base_string)
-    end
-  end
-
   describe "replace_unicode_moji_with_images" do
     it 'should return original string without emoji' do
       assert_equal "foo", Emoji.replace_unicode_moji_with_images('foo')

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -130,6 +130,22 @@ describe Emoji do
     end
   end
 
+  describe "replace_moji_with_markdown" do
+    it 'should return the original string without emoji' do
+      assert_equal "foo", Emoji.replace_moji_with_markdown('foo')
+    end
+
+    it 'should replace the unicode moji with markdown moji names' do
+      base_string = "I ❤ Emoji"
+      assert_equal "I :heart: Emoji", Emoji.replace_moji_with_markdown(base_string)
+    end
+
+    it 'should be able to replace multiple moji in one go' do
+      base_string = "I ❤ ❤ Emoji"
+      assert_equal "I :heart: :heart: Emoji", Emoji.replace_moji_with_markdown(base_string)
+    end
+  end
+
   describe "replace_unicode_moji_with_images" do
     it 'should return original string without emoji' do
       assert_equal "foo", Emoji.replace_unicode_moji_with_images('foo')


### PR DESCRIPTION
This PR would add functionality to replace emoji in the markdown formatting, eg `Hello! :smile:` with unicode moji, eg `Hello! 😊`.

Currently this is of somewhat limited utility, as many emoji in the index have nonstandard names, however, it would make many projects easier to manage.